### PR TITLE
Generate empty children nodes

### DIFF
--- a/templates/base.c
+++ b/templates/base.c
@@ -7,6 +7,7 @@
 #include <libxml2/libxml/parser.h>
 
 char scratchpad[64];
+time_t time_tmp;
 
 /* --- TYPE DECLARATIONS --- */
 {% set child = root %}

--- a/templates/dynamic_array.c.ji2
+++ b/templates/dynamic_array.c.ji2
@@ -40,8 +40,8 @@ void free_{{arrayElem_name}}_array({{arrayElem_name}}_dynArray_t *firstElement)
 {%if arrayElem_tag == 'struct' %}
 void {{arrayElem_name}}_build_xml({{arrayElem_name}}_dynArray_t *firstElement,xmlNodePtr parent)
 {
-    {{arrayElem_name}}_dynArray_t *var = firstElement;
-    while(var != NULL){
+    {{arrayElem_name}}_dynArray_t *var;
+    for (var = firstElement; var; var = var->next) {
         xmlNodePtr newNode = xmlNewNode(NULL,"{{arrayElem_name}}");
         xmlNodePtr elementNode;
 {% for node in element  %}
@@ -62,21 +62,20 @@ void {{arrayElem_name}}_build_xml({{arrayElem_name}}_dynArray_t *firstElement,xm
         {{node.text}}_array_build_xml(var->data->{{node.text}},newNode);
 {% endif %}
 {% endfor %}
-        var = var->next;
         xmlAddChild(parent, newNode);
     }
 }
 {% elif arrayElem_tag == 'param' %}
 void {{arrayElem_name}}_array_build_xml({{arrayElem_name}}_dynArray_t *firstElement,xmlNodePtr parent)
 {
-    {{arrayElem_name}}_dynArray_t *var = firstElement;
+    {{arrayElem_name}}_dynArray_t *var;
 
 {% if element_type == 'csv' %}
     xmlNodePtr newNode = xmlNewNode(NULL, "{{arrayElem_name}}");
     xmlNodeSetContent(newNode,"");
 {% endif %}
 
-    while(var != NULL){
+    for (var = firstElement; var; var = var->next) {
 {% set element_dataType = element.attrib['dataType'] %}
 {% set element_name = arrayElem_name %}
 {% set element_variable = 'var->data' %}

--- a/templates/dynamic_array.c.ji2
+++ b/templates/dynamic_array.c.ji2
@@ -40,46 +40,46 @@ void free_{{arrayElem_name}}_array({{arrayElem_name}}_dynArray_t *firstElement)
 {%if arrayElem_tag == 'struct' %}
 void {{arrayElem_name}}_build_xml({{arrayElem_name}}_dynArray_t *firstElement,xmlNodePtr parent)
 {
-    {{arrayElem_name}}_dynArray_t *target = firstElement;
-    while(target != NULL){
+    {{arrayElem_name}}_dynArray_t *var = firstElement;
+    while(var != NULL){
         xmlNodePtr newNode = xmlNewNode(NULL,"{{arrayElem_name}}");
         xmlNodePtr elementNode;
 {% for node in element  %}
 {% if node.tag == 'struct' %}
-        {{node.attrib['name']}}_build_xml(target->data->{{node.attrib['name']}}, newNode);
+        {{node.attrib['name']}}_build_xml(var->data->{{node.attrib['name']}}, newNode);
 {% elif (node.tag == 'param') and not ('type' in node.attrib.keys()) %}
         //single parameters {{node.text}}    
         elementNode = xmlNewNode(NULL,"{{node.text}}");
 {% set element = node %}
 {% set element_dataType = node.attrib['dataType'] %}
 {% set element_name = node.text %}
-{% set element_variable = 'target->data->' + element_name %}
+{% set element_variable = 'var->data->' + element_name %}
 {% set xml_operation = 'Set' %}
 {% set xml_node = 'elementNode' %}
 {% include 'templates/parameter_serialization_single.c.ji2' %}
         xmlAddChild(newNode, elementNode);
 {% elif (node.tag == 'param') and (node.attrib['type'] in ['csv','multiple'])  %}
-        {{node.text}}_array_build_xml(target->data->{{node.text}},newNode);
+        {{node.text}}_array_build_xml(var->data->{{node.text}},newNode);
 {% endif %}
 {% endfor %}
-        target = target->next;
+        var = var->next;
         xmlAddChild(parent, newNode);
     }
 }
 {% elif arrayElem_tag == 'param' %}
 void {{arrayElem_name}}_array_build_xml({{arrayElem_name}}_dynArray_t *firstElement,xmlNodePtr parent)
 {
-    {{arrayElem_name}}_dynArray_t *target = firstElement;
+    {{arrayElem_name}}_dynArray_t *var = firstElement;
 
 {% if element_type == 'csv' %}
     xmlNodePtr newNode = xmlNewNode(NULL, "{{arrayElem_name}}");
     xmlNodeSetContent(newNode,"");
 {% endif %}
 
-    while(target != NULL){
+    while(var != NULL){
 {% set element_dataType = element.attrib['dataType'] %}
 {% set element_name = arrayElem_name %}
-{% set element_variable = 'target->data' %}
+{% set element_variable = 'var->data' %}
 {% set xml_node = 'newNode' %}
 
 {% if element_type == 'multiple' %}
@@ -99,7 +99,7 @@ void {{arrayElem_name}}_array_build_xml({{arrayElem_name}}_dynArray_t *firstElem
 {% elif element_type == 'csv' %}
         xmlNodeAddContent(newNode,";");
 {% endif %}
-        target = target->next;
+        var = var->next;
     }
 
 {% if element_type == 'csv' %}

--- a/templates/parameter_serialization_single.c.ji2
+++ b/templates/parameter_serialization_single.c.ji2
@@ -4,24 +4,28 @@
 int i;
 for(i=0;i<{{element.attrib['length']}};i++){
 {% endif %}
-{% if element_dataType in ['int','uint8_t'] %}
-    sprintf(scratchpad, "%d",{{element_variable}}{%if 'length' in element.attrib.keys() %}[i]{% endif %});
-{% elif element_dataType in ['float', 'double'] %}
-    sprintf(scratchpad, "%f",{{element_variable}}{%if 'length' in element.attrib.keys() %}[i]{% endif %});
-{% elif element_dataType in ['bool'] %}
-    sprintf(scratchpad, {{element_variable}}{%if 'length' in element.attrib.keys() %}[i]{% endif %} ? "true" : "false");
-{% elif element_dataType in ['char'] %}
-    {% if 'length' in element.attrib.keys() %}
-    strcpy(scratchpad,{{element_variable}});
-    {% else %}
-    sprintf(scratchpad,"%c",{{element_variable}});
+if (var) {
+    {% if element_dataType in ['int','uint8_t'] %}
+        sprintf(scratchpad, "%d",{{element_variable}}{%if 'length' in element.attrib.keys() %}[i]{% endif %});
+    {% elif element_dataType in ['float', 'double'] %}
+        sprintf(scratchpad, "%f",{{element_variable}}{%if 'length' in element.attrib.keys() %}[i]{% endif %});
+    {% elif element_dataType in ['bool'] %}
+        sprintf(scratchpad, {{element_variable}}{%if 'length' in element.attrib.keys() %}[i]{% endif %} ? "true" : "false");
+    {% elif element_dataType in ['char'] %}
+        {% if 'length' in element.attrib.keys() %}
+        strcpy(scratchpad,{{element_variable}});
+        {% else %}
+        sprintf(scratchpad,"%c",{{element_variable}});
+        {% endif %}
+    {% elif element_dataType == 'time_t'%}
+        {
+        time_t tmp = ({{element_variable}}{%if 'length' in element.attrib.keys() %}[i]{% endif %});
+        strftime(scratchpad,64,"%Y-%jT%H:%M:%S.000Z",localtime(&tmp));
+        }
     {% endif %}
-{% elif element_dataType == 'time_t'%}
-    {
-    time_t tmp = ({{element_variable}}{%if 'length' in element.attrib.keys() %}[i]{% endif %});
-    strftime(scratchpad,64,"%Y-%jT%H:%M:%S.000Z",localtime(&tmp));
-    }
-{% endif %}
+} else {
+    bzero(scratchpad, sizeof(scratchpad));
+}
     xmlNode{{xml_operation}}Content({{xml_node}},scratchpad);
 
 {% if 'length' in element.attrib.keys() and not (element_dataType in ['char']) %}

--- a/templates/parameter_serialization_single.c.ji2
+++ b/templates/parameter_serialization_single.c.ji2
@@ -4,21 +4,17 @@
 int i;
 for(i=0;i<{{element.attrib['length']}};i++){
 {% endif %}
-
 {% if element_dataType in ['int','uint8_t'] %}
-sprintf(scratchpad, "%d",{{element_variable}}{%if 'length' in element.attrib.keys() %}[i]{% endif %});
+    sprintf(scratchpad, "%d",{{element_variable}}{%if 'length' in element.attrib.keys() %}[i]{% endif %});
 {% elif element_dataType in ['float', 'double'] %}
-sprintf(scratchpad, "%f",{{element_variable}}{%if 'length' in element.attrib.keys() %}[i]{% endif %});
+    sprintf(scratchpad, "%f",{{element_variable}}{%if 'length' in element.attrib.keys() %}[i]{% endif %});
 {% elif element_dataType in ['bool'] %}
-if({{element_variable}}{%if 'length' in element.attrib.keys() %}[i]{% endif %} == false)
-    sprintf(scratchpad,"false");
-else
-    sprintf(scratchpad, "true");
+    sprintf(scratchpad, {{element_variable}}{%if 'length' in element.attrib.keys() %}[i]{% endif %} ? "true" : "false");
 {% elif element_dataType in ['char'] %}
     {% if 'length' in element.attrib.keys() %}
-strcpy(scratchpad,{{element_variable}});
+    strcpy(scratchpad,{{element_variable}});
     {% else %}
-sprintf(scratchpad,"%c",{{element_variable}});
+    sprintf(scratchpad,"%c",{{element_variable}});
     {% endif %}
 {% elif element_dataType == 'time_t'%}
     {
@@ -26,7 +22,7 @@ sprintf(scratchpad,"%c",{{element_variable}});
     strftime(scratchpad,64,"%Y-%jT%H:%M:%S.000Z",localtime(&tmp));
     }
 {% endif %}
-xmlNode{{xml_operation}}Content({{xml_node}},scratchpad);
+    xmlNode{{xml_operation}}Content({{xml_node}},scratchpad);
 
 {% if 'length' in element.attrib.keys() and not (element_dataType in ['char']) %}
 if(i != ({{element.attrib['length']}}-1))

--- a/templates/parameter_serialization_single.c.ji2
+++ b/templates/parameter_serialization_single.c.ji2
@@ -18,10 +18,8 @@ if (var) {
         sprintf(scratchpad,"%c",{{element_variable}});
         {% endif %}
     {% elif element_dataType == 'time_t'%}
-        {
-        time_t tmp = ({{element_variable}}{%if 'length' in element.attrib.keys() %}[i]{% endif %});
-        strftime(scratchpad,64,"%Y-%jT%H:%M:%S.000Z",localtime(&tmp));
-        }
+        time_tmp = ({{element_variable}}{%if 'length' in element.attrib.keys() %}[i]{% endif %});
+        strftime(scratchpad, sizeof(scratchpad), "%Y-%jT%H:%M:%S.000Z", localtime(&time_tmp));
     {% endif %}
 } else {
     bzero(scratchpad, sizeof(scratchpad));

--- a/templates/struct_function_impl_.ji2
+++ b/templates/struct_function_impl_.ji2
@@ -107,12 +107,12 @@ void {{parent_name}}_set_{{child_name}}({{parent_name}}Ptr_t var, {{child_name}}
 {% if not (child_type in ['multiple','csv']) %}
 void {{child_name}}_build_xml({{child_name}}Ptr_t var, xmlNodePtr parent)
 {
-    if(var == NULL) return; //If the struct is not set... dont even bother
     xmlNodePtr newNode = xmlNewNode(NULL,"{{child_name}}");
     xmlNodePtr elementNode;
+
 {% for element in child %}
 {% if element.tag == 'struct' %}
-    {{element.attrib['name']}}_build_xml(var->{{element.attrib['name']}}, newNode);
+    {{element.attrib['name']}}_build_xml(var ? var->{{element.attrib['name']}} : NULL, newNode);
 {% elif (element.tag == 'param') and not ('type' in element.attrib.keys())  %}
 {% set element_dataType = element.attrib['dataType'] %}
 {% set element_name =  element.text %}
@@ -120,12 +120,15 @@ void {{child_name}}_build_xml({{child_name}}Ptr_t var, xmlNodePtr parent)
 {% set xml_operation = 'Set' %}
     elementNode = xmlNewNode(NULL,"{{element_name}}");
 {% set xml_node = 'elementNode' %}
+
 {% include 'templates/parameter_serialization_single.c.ji2' %}
+
     xmlAddChild(newNode,elementNode);
 {% elif (element.tag == 'param') and (element.attrib['type'] in ['csv','multiple'])  %}
-    {{element.text}}_array_build_xml(var->{{element.text}},newNode);
+    {{element.text}}_array_build_xml(var ? var->{{element.text}} : NULL, newNode);
 {% endif %}
 {% endfor %}
+
     xmlAddChild(parent, newNode);
 }
 {% endif %}


### PR DESCRIPTION
NULL children are now processed by creating the children node but without setting any content.

A little bit of reformatting has also been done in the process of creating the main patch, so there it is also for our joy and pleasure.